### PR TITLE
Authorization tokens (authentication stage 1)

### DIFF
--- a/app/auth/authorize_api_request.rb
+++ b/app/auth/authorize_api_request.rb
@@ -15,8 +15,7 @@ class AuthorizeApiRequest
     def user
       @user ||= User.find(decoded_auth_token[:user_id]) if decoded_auth_token
       rescue ActiveRecord::RecordNotFound => error
-        raise(
-          ExceptionHandler::InvalidToken,      ("#{Message.invalid_token} #{error.message}"))
+        raise( ExceptionHandler::InvalidToken, "Invalid token")
     end
 
     def decoded_auth_token
@@ -27,6 +26,6 @@ class AuthorizeApiRequest
       if headers["Authorization"].present?
         return headers["Authorization"].split(" ").last
       end
-      raise(ExceptionHandler::MissingToken, ("#{Message.missing_token} #{error.message}"))
+      raise(ExceptionHandler::MissingToken, "Missing token")
     end
 end

--- a/app/auth/authorize_api_request.rb
+++ b/app/auth/authorize_api_request.rb
@@ -14,8 +14,8 @@ class AuthorizeApiRequest
 
     def user
       @user ||= User.find(decoded_auth_token[:user_id]) if decoded_auth_token
-      rescue ActiveRecord::RecordNotFound => error
-        raise( ExceptionHandler::InvalidToken, "Invalid token")
+    rescue ActiveRecord::RecordNotFound => error
+      raise(ExceptionHandler::InvalidToken, "Invalid token")
     end
 
     def decoded_auth_token
@@ -24,7 +24,7 @@ class AuthorizeApiRequest
 
     def http_auth_header
       if headers["Authorization"].present?
-        return headers["Authorization"].split(" ").last
+        return headers["Authorization"]
       end
       raise(ExceptionHandler::MissingToken, "Missing token")
     end

--- a/app/auth/authorize_api_request.rb
+++ b/app/auth/authorize_api_request.rb
@@ -1,2 +1,32 @@
 class AuthorizeApiRequest
+  def initialize(headers = {})
+    @headers = headers
+  end
+
+  def call
+    {
+      user: user
+    }
+  end
+
+  private
+  attr_reader :headers
+
+  def user
+    @user ||= User.find(decoded_auth_token[:user_id]) if decoded_auth_token
+    rescue ActiveRecord::RecordNotFound => error
+      raise(
+        ExceptionHandler::InvalidToken,      ("#{Message.invalid_token} #{error.message}"))
+  end
+
+  def decoded_auth_token
+    @decoded_auth_token ||= JsonWebToken.decode(http_auth_header)
+  end
+
+  def http_auth_header
+    if headers['Authorization'].present?
+      return headers['Authorization'].split(' ').last
+    end
+      raise(ExceptionHandler::MissingToken, ("#{Message.missing_token} #{error.message}"))
+  end
 end

--- a/app/auth/authorize_api_request.rb
+++ b/app/auth/authorize_api_request.rb
@@ -10,23 +10,23 @@ class AuthorizeApiRequest
   end
 
   private
-  attr_reader :headers
+    attr_reader :headers
 
-  def user
-    @user ||= User.find(decoded_auth_token[:user_id]) if decoded_auth_token
-    rescue ActiveRecord::RecordNotFound => error
-      raise(
-        ExceptionHandler::InvalidToken,      ("#{Message.invalid_token} #{error.message}"))
-  end
-
-  def decoded_auth_token
-    @decoded_auth_token ||= JsonWebToken.decode(http_auth_header)
-  end
-
-  def http_auth_header
-    if headers['Authorization'].present?
-      return headers['Authorization'].split(' ').last
+    def user
+      @user ||= User.find(decoded_auth_token[:user_id]) if decoded_auth_token
+      rescue ActiveRecord::RecordNotFound => error
+        raise(
+          ExceptionHandler::InvalidToken,      ("#{Message.invalid_token} #{error.message}"))
     end
+
+    def decoded_auth_token
+      @decoded_auth_token ||= JsonWebToken.decode(http_auth_header)
+    end
+
+    def http_auth_header
+      if headers["Authorization"].present?
+        return headers["Authorization"].split(" ").last
+      end
       raise(ExceptionHandler::MissingToken, ("#{Message.missing_token} #{error.message}"))
-  end
+    end
 end

--- a/app/auth/authorize_api_request.rb
+++ b/app/auth/authorize_api_request.rb
@@ -1,31 +1,7 @@
 class AuthorizeApiRequest
-  def initialize(headers = {})
-    @headers = headers
+  def self.get_user(encoded_token)
+    raise(ExceptionHandler::MissingToken, "Missing token") if encoded_token.blank?
+    token_data = JsonWebToken.decode(encoded_token)
+    User.find(token_data[:user_id])
   end
-
-  def call
-    {
-      user: user
-    }
-  end
-
-  private
-    attr_reader :headers
-
-    def user
-      @user ||= User.find(decoded_auth_token[:user_id]) if decoded_auth_token
-    rescue ActiveRecord::RecordNotFound => error
-      raise(ExceptionHandler::InvalidToken, "Invalid token")
-    end
-
-    def decoded_auth_token
-      @decoded_auth_token ||= JsonWebToken.decode(http_auth_header)
-    end
-
-    def http_auth_header
-      if headers["Authorization"].present?
-        return headers["Authorization"]
-      end
-      raise(ExceptionHandler::MissingToken, "Missing token")
-    end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,6 @@ class ApplicationController < ActionController::API
 
   private
     def authorize_request
-      @current_user = (AuthorizeApiRequest.new(request.headers).call)[:user]
+      @current_user = AuthorizeApiRequest.get_user(request.headers["Authorization"])
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,5 @@ class ApplicationController < ActionController::API
     def authorize_request
       @current_user = AuthorizeApiRequest.get_user(request.headers["Authorization"])
     end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,11 @@ class ApplicationController < ActionController::API
   include Response
   include ExceptionHandler
 
-  def authorize_request
-    @current_user = (AuthorizeApiRequest.new(request.headers).call)[:user]
-  end
+  before_action :authorize_request
+  attr_reader :current_user
+
+  private
+    def authorize_request
+      @current_user = (AuthorizeApiRequest.new(request.headers).call)[:user]
+    end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationController < ActionController::API
   include Response
   include ExceptionHandler
+
+  def authorize_request
+    @current_user = (AuthorizeApiRequest.new(request.headers).call)[:user]
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   skip_before_action :authorize_request, only: :create
-  
+
   def index
     @users = User.all
     json_response(@users, :ok)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  skip_before_action :authorize_request, only: :create
+  
   def index
     @users = User.all
     json_response(@users, :ok)

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -1,5 +1,5 @@
 class JsonWebToken
-  SECRET_SIGNATURE = Rails.application.secrets.secret_key_base
+  SECRET_SIGNATURE = MentorBeeApi::Application.credentials.secret_key_base
 
   def self.encode(user, expiry = 24.hours.from_now)
     user[:expiry] = expiry.to_i

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -2,7 +2,7 @@ class JsonWebToken
   SECRET_SIGNATURE = MentorBeeApi::Application.credentials.secret_key_base
 
   def self.encode(user, expiry = 24.hours.from_now)
-    user[:expiry] = expiry.to_i
+    user[:exp] = expiry.to_i
     JWT.encode(user, SECRET_SIGNATURE)
   end
 
@@ -10,7 +10,7 @@ class JsonWebToken
     body = JWT.decode(token, SECRET_SIGNATURE)[0]
     HashWithIndifferentAccess.new body
 
-  rescue JWT::DecodeError => error
-    raise ExceptionHandler::InvalidToken, error.message
+    rescue JWT::DecodeError => error
+      raise ExceptionHandler::InvalidToken, error.message
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2018_10_19_162441) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/auth/authorize_api_request_spec.rb
+++ b/spec/auth/authorize_api_request_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe AuthorizeApiRequest, focus: true do
+RSpec.describe AuthorizeApiRequest do
   let(:user) { create(:user) }
   let(:header) { { "Authorization" => token_generator(user.id) } }
 
@@ -29,6 +29,14 @@ RSpec.describe AuthorizeApiRequest, focus: true do
 
         it "raises the InvalidToken error" do
           expect { invalid_request_object.call }.to raise_error(ExceptionHandler::InvalidToken, "Invalid token")
+        end
+      end
+
+      context "when token is expired (>24hr)" do
+        let(:header) { { "Authorization" => expired_token_generator(user.id) } }
+
+        it "raises expired signature error" do
+          expect { valid_request_object.call }.to raise_error(ExceptionHandler::InvalidToken, "Signature has expired")
         end
       end
     end

--- a/spec/auth/authorize_api_request_spec.rb
+++ b/spec/auth/authorize_api_request_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
-RSpec.describe AuthorizeApiRequest do
+RSpec.describe AuthorizeApiRequest, focus: true do
   let(:user) { create(:user) }
   let(:header) { { "Authorization" => token_generator(user.id) } }
 
-  subject(:valid_request_object) { AuthorizeApiRequest.new(header) }
+  subject(:valid_request_object) { described_class.new(header) }
   subject(:invalid_request_object) { described_class.new({}) }
 
   describe "#call" do
@@ -12,6 +12,14 @@ RSpec.describe AuthorizeApiRequest do
       it "returns the user object" do
         result = valid_request_object.call
         expect(result[:user]).to eq(user)
+      end
+    end
+
+    context "when the request is invalid" do
+      context "if the token is missing" do
+        it "raises the MissingToken error" do
+          expect { invalid_request_object.call }.to raise_error(ExceptionHandler::MissingToken, "Missing token")
+        end
       end
     end
   end

--- a/spec/auth/authorize_api_request_spec.rb
+++ b/spec/auth/authorize_api_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AuthorizeApiRequest do
   subject(:valid_request_object) { described_class.get_user(header["Authorization"]) }
   subject(:invalid_request_object) { described_class.get_user(nil) }
 
-  describe "#call" do
+  describe "#get_user" do
     context "when request is valid" do
       it "returns the user object" do
         result = valid_request_object

--- a/spec/auth/authorize_api_request_spec.rb
+++ b/spec/auth/authorize_api_request_spec.rb
@@ -40,5 +40,13 @@ RSpec.describe AuthorizeApiRequest do
         end
       end
     end
+
+    context "when a fake token is given" do
+        let(:header) { { "Authorization" => "qwerty" } }
+
+        it "handles JWT::DecodeError" do
+          expect { valid_request_object.call }.to raise_error(ExceptionHandler::InvalidToken, "Not enough or too many segments")
+        end
+      end
   end
 end

--- a/spec/auth/authorize_api_request_spec.rb
+++ b/spec/auth/authorize_api_request_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
-RSpec.describe AuthorizeApiRequest do
+RSpec.describe AuthorizeApiRequest, focus: true do
   let(:user) { create(:user) }
-  let(:header) { { 'Authorization' => token_generator(user.id) } }
+  let(:header) { { "Authorization" => token_generator(user.id) } }
 
-  subject(:valid_request_object) { described_class.new(header) }
+  subject(:valid_request_object) { AuthorizeApiRequest.new(header) }
   subject(:invalid_request_object) { described_class.new({}) }
 
   describe "#call" do

--- a/spec/auth/authorize_api_request_spec.rb
+++ b/spec/auth/authorize_api_request_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe AuthorizeApiRequest, focus: true do
+RSpec.describe AuthorizeApiRequest do
   let(:user) { create(:user) }
   let(:header) { { "Authorization" => token_generator(user.id) } }
 

--- a/spec/auth/authorize_api_request_spec.rb
+++ b/spec/auth/authorize_api_request_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe AuthorizeApiRequest, focus: true do
           expect { invalid_request_object.call }.to raise_error(ExceptionHandler::MissingToken, "Missing token")
         end
       end
+
+      context "when invalid token is given" do
+        subject(:invalid_request_object) do
+          described_class.new("Authorization" => token_generator(5))
+        end
+
+        it "raises the InvalidToken error" do
+          expect { invalid_request_object.call }.to raise_error(ExceptionHandler::InvalidToken, "Invalid token")
+        end
+      end
     end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ApplicationController, type: :controller do
 
   describe "#authorize_request" do
     context "when authentication token is given" do
-      before { allow(request).to receive(:headers).and_return(headers)}
+      before { allow(request).to receive(:headers).and_return(headers) }
 
       it "sets the current user when authorized successfully" do
         expect(subject.instance_eval { authorize_request }).to eq(user)
@@ -15,10 +15,10 @@ RSpec.describe ApplicationController, type: :controller do
     end
 
     context "when authentication token is not given" do
-      before { allow(request).to receive(:headers).and_return(tokenless_headers)}
+      before { allow(request).to receive(:headers).and_return(tokenless_headers) }
 
       it "sets the current user when authorized successfully" do
-        expect{ subject.instance_eval { authorize_request } }.to raise_error(ExceptionHandler::MissingToken, "Missing token")
+        expect { subject.instance_eval { authorize_request } }.to raise_error(ExceptionHandler::MissingToken, "Missing token")
       end
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe ApplicationController, type: :controller do
+  let!(:user) { create(:user) }
+  let(:headers) { { "Authorization" => token_generator(user.id) } }
+  let(:tokenless_headers) { { "Authorization" => nil } }
+
+  describe "#authorize_request" do
+    context "when authentication token is given" do
+      before { allow(request).to receive(:headers).and_return(headers)}
+
+      it "sets the current user when authorized successfully" do
+        expect(subject.instance_eval { authorize_request }).to eq(user)
+      end
+    end
+
+    context "when authentication token is not given" do
+      before { allow(request).to receive(:headers).and_return(tokenless_headers)}
+
+      it "sets the current user when authorized successfully" do
+        expect{ subject.instance_eval { authorize_request } }.to raise_error(ExceptionHandler::MissingToken, "Missing token")
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,7 +72,8 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
-  config.include RequestSpecHelper, type: :request
+  config.include RequestSpecHelper
+  config.include ControllerSpecHelper
 
   config.include FactoryBot::Syntax::Methods
 

--- a/spec/requests/mentees_controller_spec.rb
+++ b/spec/requests/mentees_controller_spec.rb
@@ -2,10 +2,9 @@ require "rails_helper"
 
 RSpec.describe MenteesController, type: :request do
   let!(:mentees) { create_list(:mentee, 5) }
-  let(:headers) { valid_headers }
 
   describe "GET /mentees" do
-    before { get "/mentees", params: {}, headers: headers }
+    before { get "/mentees", params: {}, headers: valid_headers }
 
     it "returns mentees" do
       expect(json).not_to be_empty
@@ -21,13 +20,13 @@ RSpec.describe MenteesController, type: :request do
     let(:mentee) { create(:mentee) }
 
     context "request is valid" do
-      before { get "/mentees/#{mentee.id}", params: {}, headers: headers }
+      before { get "/mentees/#{mentee.id}", params: {}, headers: valid_headers }
       it "returns mentees" do
         expect(json["interest"]).to eq(mentee.interest)
       end
     end
     context "request is invalid" do
-      before { get "/mentees/0", params: {}, headers: headers }
+      before { get "/mentees/0", params: {}, headers: valid_headers }
       it "returns a failure message" do
         expect(response.body).to eq("{\"message\":\"Couldn't find Mentee\"}")
       end
@@ -45,7 +44,7 @@ RSpec.describe MenteesController, type: :request do
     let(:invalid_attributes) { { mentee: { user_id: user.id, bio: "Expecto Patronum" } }.to_json }
 
     context "request is valid" do
-      before { post "/mentees", params: valid_attributes, headers: headers }
+      before { post "/mentees", params: valid_attributes, headers: valid_headers }
       it "creates a mentee" do
         expect(json["interest"]).to eq("Lumos")
       end
@@ -54,7 +53,7 @@ RSpec.describe MenteesController, type: :request do
       end
     end
     context "request is invalid" do
-      before { post "/mentees", params: invalid_attributes, headers: headers }
+      before { post "/mentees", params: invalid_attributes, headers: valid_headers }
       it "returns a failure message" do
         expect(response.body).to eq("{\"message\":\"Validation failed: Interest can't be blank\"}")
       end

--- a/spec/requests/mentees_controller_spec.rb
+++ b/spec/requests/mentees_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe MenteesController, type: :request do
-  let(:user) { create(:user) }
   let!(:mentees) { create_list(:mentee, 5) }
   let(:headers) { valid_headers }
 

--- a/spec/requests/mentees_controller_spec.rb
+++ b/spec/requests/mentees_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe MenteesController, type: :request, focus: true do
+RSpec.describe MenteesController, type: :request do
   let(:user) { create(:user) }
   let!(:mentees) { create_list(:mentee, 5) }
   let(:headers) { valid_headers }
@@ -40,7 +40,7 @@ RSpec.describe MenteesController, type: :request, focus: true do
 
   describe "POST /mentees" do
     let(:user) { create(:user) }
-    
+
     let(:valid_attributes) { { mentee: { user_id: user.id, bio: "Expecto Patronum", interest: "Lumos" } }.to_json }
 
     let(:invalid_attributes) { { mentee: { user_id: user.id, bio: "Expecto Patronum" } }.to_json }

--- a/spec/requests/mentees_controller_spec.rb
+++ b/spec/requests/mentees_controller_spec.rb
@@ -1,10 +1,12 @@
 require "rails_helper"
 
-RSpec.describe MenteesController, type: :request do
+RSpec.describe MenteesController, type: :request, focus: true do
+  let(:user) { create(:user) }
   let!(:mentees) { create_list(:mentee, 5) }
+  let(:headers) { valid_headers }
 
   describe "GET /mentees" do
-    before { get "/mentees" }
+    before { get "/mentees", params: {}, headers: headers }
 
     it "returns mentees" do
       expect(json).not_to be_empty
@@ -20,13 +22,13 @@ RSpec.describe MenteesController, type: :request do
     let(:mentee) { create(:mentee) }
 
     context "request is valid" do
-      before { get "/mentees/#{mentee.id}" }
+      before { get "/mentees/#{mentee.id}", params: {}, headers: headers }
       it "returns mentees" do
         expect(json["interest"]).to eq(mentee.interest)
       end
     end
     context "request is invalid" do
-      before { get "/mentees/0" }
+      before { get "/mentees/0", params: {}, headers: headers }
       it "returns a failure message" do
         expect(response.body).to eq("{\"message\":\"Couldn't find Mentee\"}")
       end
@@ -38,11 +40,13 @@ RSpec.describe MenteesController, type: :request do
 
   describe "POST /mentees" do
     let(:user) { create(:user) }
-    let(:valid_attributes) { { mentee: { user_id: user.id, bio: "Expecto Patronum", interest: "Lumos" } } }
-    let(:invalid_attributes) { { mentee: { user_id: user.id, bio: "Expecto Patronum" } } }
+    
+    let(:valid_attributes) { { mentee: { user_id: user.id, bio: "Expecto Patronum", interest: "Lumos" } }.to_json }
+
+    let(:invalid_attributes) { { mentee: { user_id: user.id, bio: "Expecto Patronum" } }.to_json }
 
     context "request is valid" do
-      before { post "/mentees", params: valid_attributes }
+      before { post "/mentees", params: valid_attributes, headers: headers }
       it "creates a mentee" do
         expect(json["interest"]).to eq("Lumos")
       end
@@ -51,7 +55,7 @@ RSpec.describe MenteesController, type: :request do
       end
     end
     context "request is invalid" do
-      before { post "/mentees", params: invalid_attributes }
+      before { post "/mentees", params: invalid_attributes, headers: headers }
       it "returns a failure message" do
         expect(response.body).to eq("{\"message\":\"Validation failed: Interest can't be blank\"}")
       end

--- a/spec/requests/mentors_controller_spec.rb
+++ b/spec/requests/mentors_controller_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-RSpec.describe MentorsController, type: :request, focus: true do
+RSpec.describe MentorsController, type: :request do
   let!(:mentors) { create_list(:mentor, 5) }
-  let(:user) { create(:user) }
   let(:headers) { valid_headers }
 
   describe "GET /mentors" do
@@ -42,7 +41,7 @@ RSpec.describe MentorsController, type: :request, focus: true do
     let(:user) { create(:user) }
 
     let(:valid_attributes) { { mentor: { user_id: user.id, bio: "Expecto Patronum", skill: "Lumos" } }.to_json }
-    
+
     let(:invalid_attributes) { { mentor: { user_id: user.id, bio: "Expecto Patronum" } }.to_json }
 
     context "request is valid" do

--- a/spec/requests/mentors_controller_spec.rb
+++ b/spec/requests/mentors_controller_spec.rb
@@ -2,10 +2,9 @@ require "rails_helper"
 
 RSpec.describe MentorsController, type: :request do
   let!(:mentors) { create_list(:mentor, 5) }
-  let(:headers) { valid_headers }
 
   describe "GET /mentors" do
-    before { get "/mentors", params: {}, headers: headers }
+    before { get "/mentors", params: {}, headers: valid_headers }
 
     it "returns mentors" do
       expect(json).not_to be_empty
@@ -21,13 +20,13 @@ RSpec.describe MentorsController, type: :request do
     let(:mentor) { create(:mentor) }
 
     context "request is valid" do
-      before { get "/mentors/#{mentor.id}", params: {}, headers: headers }
+      before { get "/mentors/#{mentor.id}", params: {}, headers: valid_headers }
       it "returns mentors" do
         expect(json["skill"]).to eq(mentor.skill)
       end
     end
     context "request is invalid" do
-      before { get "/mentors/0", params: {}, headers: headers }
+      before { get "/mentors/0", params: {}, headers: valid_headers }
       it "returns a failure message" do
         expect(response.body).to eq("{\"message\":\"Couldn't find Mentor\"}")
       end
@@ -45,7 +44,7 @@ RSpec.describe MentorsController, type: :request do
     let(:invalid_attributes) { { mentor: { user_id: user.id, bio: "Expecto Patronum" } }.to_json }
 
     context "request is valid" do
-      before { post "/mentors", params: valid_attributes, headers: headers }
+      before { post "/mentors", params: valid_attributes, headers: valid_headers }
       it "creates a mentor" do
         expect(json["skill"]).to eq("Lumos")
       end
@@ -54,7 +53,7 @@ RSpec.describe MentorsController, type: :request do
       end
     end
     context "request is invalid" do
-      before { post "/mentors", params: invalid_attributes, headers: headers }
+      before { post "/mentors", params: invalid_attributes, headers: valid_headers }
       it "returns a failure message" do
         expect(response.body).to eq("{\"message\":\"Validation failed: Skill can't be blank\"}")
       end

--- a/spec/requests/mentors_controller_spec.rb
+++ b/spec/requests/mentors_controller_spec.rb
@@ -1,10 +1,12 @@
 require "rails_helper"
 
-RSpec.describe MentorsController, type: :request do
+RSpec.describe MentorsController, type: :request, focus: true do
   let!(:mentors) { create_list(:mentor, 5) }
+  let(:user) { create(:user) }
+  let(:headers) { valid_headers }
 
   describe "GET /mentors" do
-    before { get "/mentors" }
+    before { get "/mentors", params: {}, headers: headers }
 
     it "returns mentors" do
       expect(json).not_to be_empty
@@ -20,13 +22,13 @@ RSpec.describe MentorsController, type: :request do
     let(:mentor) { create(:mentor) }
 
     context "request is valid" do
-      before { get "/mentors/#{mentor.id}" }
+      before { get "/mentors/#{mentor.id}", params: {}, headers: headers }
       it "returns mentors" do
         expect(json["skill"]).to eq(mentor.skill)
       end
     end
     context "request is invalid" do
-      before { get "/mentors/0" }
+      before { get "/mentors/0", params: {}, headers: headers }
       it "returns a failure message" do
         expect(response.body).to eq("{\"message\":\"Couldn't find Mentor\"}")
       end
@@ -38,11 +40,13 @@ RSpec.describe MentorsController, type: :request do
 
   describe "POST /mentors" do
     let(:user) { create(:user) }
-    let(:valid_attributes) { { mentor: { user_id: user.id, bio: "Expecto Patronum", skill: "Lumos" } } }
-    let(:invalid_attributes) { { mentor: { user_id: user.id, bio: "Expecto Patronum" } } }
+
+    let(:valid_attributes) { { mentor: { user_id: user.id, bio: "Expecto Patronum", skill: "Lumos" } }.to_json }
+    
+    let(:invalid_attributes) { { mentor: { user_id: user.id, bio: "Expecto Patronum" } }.to_json }
 
     context "request is valid" do
-      before { post "/mentors", params: valid_attributes }
+      before { post "/mentors", params: valid_attributes, headers: headers }
       it "creates a mentor" do
         expect(json["skill"]).to eq("Lumos")
       end
@@ -51,7 +55,7 @@ RSpec.describe MentorsController, type: :request do
       end
     end
     context "request is invalid" do
-      before { post "/mentors", params: invalid_attributes }
+      before { post "/mentors", params: invalid_attributes, headers: headers }
       it "returns a failure message" do
         expect(response.body).to eq("{\"message\":\"Validation failed: Skill can't be blank\"}")
       end

--- a/spec/requests/mentorships_controller_spec.rb
+++ b/spec/requests/mentorships_controller_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 RSpec.describe MentorshipsController, type: :request do
+  let(:headers) { valid_headers }
+
   describe "GET /mentorships" do
     let!(:mentorships) { create_list(:mentorship, 5) }
 
-    before { get "/mentorships" }
-
+    before { get "/mentorships", params: {}, headers: headers }
     it "returns mentorships" do
       expect(json).not_to be_empty
       expect(json.size).to eq(5)
@@ -15,10 +16,11 @@ RSpec.describe MentorshipsController, type: :request do
   describe "POST /mentorships" do
     let(:mentor) { create(:mentor) }
     let(:mentee) { create(:mentee) }
-    let(:valid_attributes) { { mentorship: { mentor_id: mentor.id, mentee_id: mentee.id } } }
+
+    let(:valid_attributes) { { mentorship: { mentor_id: mentor.id, mentee_id: mentee.id } }.to_json }
 
     context "request is valid" do
-      before { post "/mentorships", params: valid_attributes }
+      before { post "/mentorships", params: valid_attributes, headers: headers }
       it "creates a mentorship" do
         expect(json["mentor_id"]).to eq(mentor.id)
       end

--- a/spec/requests/mentorships_controller_spec.rb
+++ b/spec/requests/mentorships_controller_spec.rb
@@ -1,12 +1,10 @@
 require "rails_helper"
 
 RSpec.describe MentorshipsController, type: :request do
-  let(:headers) { valid_headers }
-
   describe "GET /mentorships" do
     let!(:mentorships) { create_list(:mentorship, 5) }
 
-    before { get "/mentorships", params: {}, headers: headers }
+    before { get "/mentorships", params: {}, headers: valid_headers }
     it "returns mentorships" do
       expect(json).not_to be_empty
       expect(json.size).to eq(5)
@@ -20,7 +18,7 @@ RSpec.describe MentorshipsController, type: :request do
     let(:valid_attributes) { { mentorship: { mentor_id: mentor.id, mentee_id: mentee.id } }.to_json }
 
     context "request is valid" do
-      before { post "/mentorships", params: valid_attributes, headers: headers }
+      before { post "/mentorships", params: valid_attributes, headers: valid_headers }
       it "creates a mentorship" do
         expect(json["mentor_id"]).to eq(mentor.id)
       end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2,10 +2,9 @@ require "rails_helper"
 
 RSpec.describe UsersController, type: :request do
   let!(:users) { create_list(:user, 5) }
-  let(:headers) { valid_headers }
 
   describe "GET /users" do
-    before { get "/users", params: {}, headers: headers }
+    before { get "/users", params: {}, headers: valid_headers }
 
     it "returns users" do
       expect(json).not_to be_empty
@@ -47,7 +46,7 @@ RSpec.describe UsersController, type: :request do
     let(:nonexistent_user_id) { 0 }
 
     context "when the user exists" do
-      before { get "/users/#{user_id}", headers: headers }
+      before { get "/users/#{user_id}", headers: valid_headers }
       it "returns a user" do
         expect(json["id"]).to eq(user_id)
       end
@@ -57,7 +56,7 @@ RSpec.describe UsersController, type: :request do
     end
 
     context "when the user doesn't exist" do
-      before { get "/users/#{nonexistent_user_id}", headers: headers }
+      before { get "/users/#{nonexistent_user_id}", headers: valid_headers }
       it "returns a failure message" do
         expect(response.body).to eq("{\"message\":\"Couldn't find User\"}")
       end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2,13 +2,14 @@ require "rails_helper"
 
 RSpec.describe UsersController, type: :request do
   let!(:users) { create_list(:user, 5) }
+  let(:headers) { valid_headers }
 
   describe "GET /users" do
-    before { get "/users" }
+    before { get "/users", params: {}, headers: headers }
 
     it "returns users" do
       expect(json).not_to be_empty
-      expect(json.size).to eq(5)
+      expect(json.size).to eq(User.count)
     end
 
     it "returns status code 200" do
@@ -46,7 +47,7 @@ RSpec.describe UsersController, type: :request do
     let(:nonexistent_user_id) { 0 }
 
     context "when the user exists" do
-      before { get "/users/#{user_id}" }
+      before { get "/users/#{user_id}", headers: headers }
       it "returns a user" do
         expect(json["id"]).to eq(user_id)
       end
@@ -56,7 +57,7 @@ RSpec.describe UsersController, type: :request do
     end
 
     context "when the user doesn't exist" do
-      before { get "/users/#{nonexistent_user_id}" }
+      before { get "/users/#{nonexistent_user_id}", headers: headers }
       it "returns a failure message" do
         expect(response.body).to eq("{\"message\":\"Couldn't find User\"}")
       end

--- a/spec/support/controller_spec_helper.rb
+++ b/spec/support/controller_spec_helper.rb
@@ -3,6 +3,10 @@ module ControllerSpecHelper
     JsonWebToken.encode(user_id: user_id)
   end
 
+  def expired_token_generator(user_id)
+    JsonWebToken.encode({ user_id: user_id }, (Time.now.to_i - 500000000))
+  end
+
   def valid_headers
     {
       "Authorization" => token_generator(user.id),

--- a/spec/support/controller_spec_helper.rb
+++ b/spec/support/controller_spec_helper.rb
@@ -4,12 +4,12 @@ module ControllerSpecHelper
   end
 
   def expired_token_generator(user_id)
-    JsonWebToken.encode({ user_id: user_id }, (Time.now.to_i - 500000000))
+    JsonWebToken.encode({ user_id: user_id }, 1.day.ago.to_i)
   end
 
   def valid_headers
     {
-      "Authorization" => token_generator(user.id),
+      "Authorization" => token_generator(create(:user).id),
       "Content-Type" => "application/json"
     }
  end

--- a/spec/support/controller_spec_helper.rb
+++ b/spec/support/controller_spec_helper.rb
@@ -1,0 +1,21 @@
+module ControllerSpecHelper
+
+  def token_generator(user_id)
+    JsonWebToken.encode(user_id: user_id)
+  end
+
+  def valid_headers
+   {
+     "Authorization" => token_generator(user.id),
+     "Content-Type" => "application/json"
+   }
+ end
+
+ def invalid_headers
+    {
+      "Authorization" => nil,
+      "Content-Type" => "application/json"
+    }
+  end
+
+end

--- a/spec/support/controller_spec_helper.rb
+++ b/spec/support/controller_spec_helper.rb
@@ -1,21 +1,19 @@
 module ControllerSpecHelper
-
   def token_generator(user_id)
     JsonWebToken.encode(user_id: user_id)
   end
 
   def valid_headers
-   {
-     "Authorization" => token_generator(user.id),
-     "Content-Type" => "application/json"
-   }
+    {
+      "Authorization" => token_generator(user.id),
+      "Content-Type" => "application/json"
+    }
  end
 
- def invalid_headers
+  def invalid_headers
     {
       "Authorization" => nil,
       "Content-Type" => "application/json"
     }
-  end
-
+   end
 end


### PR DESCRIPTION
This is stage 1 in authentication, and adds token-based authentication to calls to this API 
Features:
- Makes use of JWT (json web tokens) in Authorization headers of HTTP requests
- Adds class JsonWebToken to handle encoding & decoding based off of the API's secret key
- Error handler to ensure we can rescue various types of errors 
- New class AuthorizeApiRequest which is called by ApplicationController's #authorize_request on any new API call (with the exception of User#create, more info below). It takes a look at the Authorization section of HTTP headers, and use the JsonWebToken methods to decode any tokens in there, and retrieves a user if it is a valid token.
- User#create method skips the authorize_request been skipped (because if you're a new user signing up, you won't have an auth token, yet). 
- ApplicationController then also sets @current_user based off the auth token received, and exposes it via attr_reader, meaning it can now be used elsewhere (yay!)